### PR TITLE
chore(charts): remove spotify-docker-gc

### DIFF
--- a/charts/workflow-e2e/requirements.yaml
+++ b/charts/workflow-e2e/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: spotify-docker-gc
-    version: 0.1.0
-    repository: https://kubernetes-charts.storage.googleapis.com

--- a/charts/workflow-e2e/values.yaml
+++ b/charts/workflow-e2e/values.yaml
@@ -6,9 +6,3 @@ ginkgo_nodes: 15
 cli_version: "latest"
 test: "e2e"
 debug_mode: "false"
-
-spotify-docker-gc:
-  cron:
-    schedule: "*/1 * * * *"
-  env:
-    dockerAPIVersion: "1.23"


### PR DESCRIPTION
Since this seems to mess up rancher somewhat (see https://github.com/rancher/rancher/issues/15364).

Also, we don't really need that - and even if we did, this isn't something that should start with the tests.