### PR TITLE
fix(charts): use deis-controller service account

### DIFF
--- a/charts/workflow-e2e/templates/workflow-e2e-pod.yaml
+++ b/charts/workflow-e2e/templates/workflow-e2e-pod.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deis
 spec:
+  serviceAccount: deis-controller
   restartPolicy: Never
   containers:
   - name: tests


### PR DESCRIPTION
So that the test pod can list pods in app namespaces (which it needs for the assertions in some tests).